### PR TITLE
Step1: Add the next-drupal npm package, adjust next config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
 module.exports = {
-  reactStrictMode: true,
+  images: {
+    domains: [process.env.NEXT_IMAGE_DOMAIN],
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1031,6 +1031,14 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.19.0.tgz",
       "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ=="
     },
+    "drupal-jsonapi-params": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/drupal-jsonapi-params/-/drupal-jsonapi-params-1.2.2.tgz",
+      "integrity": "sha512-DxTBYmfzx5TN6hFyBQgczbgxWL/qMo08wiWX+911ViOMgRHcnLzLFHZqHzK1vv1Q0PyPeDtKEgJd/u5F6gYCRw==",
+      "requires": {
+        "qs": "^6.10.0"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.3.818",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.818.tgz",
@@ -2306,6 +2314,11 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsona": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/jsona/-/jsona-1.9.2.tgz",
+      "integrity": "sha512-+af2mw8JbVUBNVFymWhovX8OV02xBKYTt8oST4HOmyfrLMfdWpatSrhvdldUTTcByzbWb4tgPbaZXaAV5yAbfg=="
+    },
     "jsx-ast-utils": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
@@ -2569,6 +2582,15 @@
         "util": "0.12.3",
         "vm-browserify": "1.1.2",
         "watchpack": "2.1.1"
+      }
+    },
+    "next-drupal": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/next-drupal/-/next-drupal-0.15.0.tgz",
+      "integrity": "sha512-+JDyhD87ORzZ1la9VpfXgHwyyOxLGbpw7sSfrwn/CvJrN1+IWAVXEqrzeOZuZFqwYfOtKLuQOnF+2M7Hu5xnvA==",
+      "requires": {
+        "drupal-jsonapi-params": "^1.2.0",
+        "jsona": "^1.8.0"
       }
     },
     "node-fetch": {
@@ -3154,6 +3176,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "querystring": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "next": "11.1.0",
+    "next-drupal": "^0.15.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },


### PR DESCRIPTION
In this first step, we just add the next-drupal npm package from https://www.npmjs.com/package/next-drupal, 
and we adjust the configuration for next.js, allowing images to be fetched from the drupal domain. 