### PR TITLE
Step 2: Add a list of published articles to the frontpage.

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -1,0 +1,31 @@
+import React from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+export function ArticleTeaser({ article }) {
+  return (
+    <div className="article-teaser">
+      <div className="article-content">
+        <figure>
+          <Image
+            src={`${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}${article.field_image.uri.url}`}
+            width={200}
+            height={200}
+            layout="responsive"
+            objectFit="cover"
+            alt={article.field_image.resourceIdObjMeta.alt}
+          />
+        </figure>
+        <Link href={article?.path?.alias}>
+          <a>
+            <h2>{article.title}</h2>
+          </a>
+        </Link>
+        <small>
+          By <strong>{article.uid.display_name}</strong>
+        </small>
+        <p>{article.body.summary}</p>
+      </div>
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,9 @@
 import Head from "next/head";
+import { getResourceCollectionFromContext } from "next-drupal";
 
-export default function Home() {
+import { ArticleTeaser } from "../components/Article";
+
+export default function Home({ articles }) {
   return (
     <div id="main-container">
       <Head>
@@ -9,7 +12,36 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className="main">Here we will show a list of posts.</main>
+      <main className="main">
+        {articles?.length ? (
+          articles.map((article) => (
+            <ArticleTeaser key={article.id} article={article} />
+          ))
+        ) : (
+          <p>No articles found.</p>
+        )}
+      </main>
     </div>
   );
+}
+
+export async function getStaticProps(context) {
+  const articles = await getResourceCollectionFromContext(
+    "node--article",
+    context,
+    {
+      params: {
+        include: "uid,field_image",
+        sort: "-created",
+        "filter[status]": "1",
+      },
+    }
+  );
+
+  return {
+    props: {
+      articles,
+    },
+    revalidate: 60,
+  };
 }


### PR DESCRIPTION
In this step we are taking care of the index of the site, where we want to show a list of the published articles.

We are using the [getResourceCollectionByContext](https://next-drupal.org/docs/reference#getresourcecollectionfromContext) method provided by next-drupal to fetch all the published articles with the data we need, then using normal next.js techniques to show a list of teasers for the articles, for which we are creating a react component.

