### PR TITLE
Step 5: Add preview capabilities

### DIFF
--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import Link from "next/link";
 import { ArticleFull } from "../components/Article";
 import { getPathsFromContext, getResourceFromContext } from "next-drupal";
 
@@ -15,9 +16,9 @@ export default function ArticlePage({ node, preview }) {
       <ArticleFull article={node} />
       {preview && (
         <div className="preview-exit-button">
-          <a href="/api/exit-preview" className="button">
-            Exit preview
-          </a>
+          <Link href="/api/exit-preview">
+            <a className="button">Exit preview</a>
+          </Link>
         </div>
       )}
     </div>

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -2,7 +2,7 @@ import Head from "next/head";
 import { ArticleFull } from "../components/Article";
 import { getPathsFromContext, getResourceFromContext } from "next-drupal";
 
-export default function ArticlePage({ node }) {
+export default function ArticlePage({ node, preview }) {
   if (!node) return null;
 
   return (
@@ -13,6 +13,13 @@ export default function ArticlePage({ node }) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <ArticleFull article={node} />
+      {preview && (
+        <div className="preview-exit-button">
+          <a href="/api/exit-preview" className="button">
+            Exit preview
+          </a>
+        </div>
+      )}
     </div>
   );
 }
@@ -31,7 +38,7 @@ export async function getStaticProps(context) {
     },
   });
 
-  if (!node?.status) {
+  if (!node?.status && !context.preview) {
     return {
       notFound: true,
     };
@@ -39,6 +46,7 @@ export async function getStaticProps(context) {
 
   return {
     props: {
+      preview: context.preview || false,
       node,
     },
     revalidate: 60,

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -2,7 +2,7 @@ import Head from "next/head";
 import { ArticleFull } from "../components/Article";
 import { getPathsFromContext, getResourceFromContext } from "next-drupal";
 
-export default function ArticlePage({ node, preview }) {
+export default function ArticlePage({ node }) {
   if (!node) return null;
 
   return (

--- a/pages/api/exit-preview.js
+++ b/pages/api/exit-preview.js
@@ -1,0 +1,7 @@
+import { NextApiResponse } from "next";
+
+export default async function exit(_, response) {
+  response.clearPreviewData();
+  response.writeHead(307, { Location: "/" });
+  response.end();
+}

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -1,0 +1,3 @@
+import { DrupalPreview } from "next-drupal";
+
+export default DrupalPreview();


### PR DESCRIPTION
In this step, we are making our blog capable of switching into [preview mode](https://nextjs.org/docs/advanced-features/preview-mode) to allow content editors using drupal to instantly preview unpublished content and newly modified content easily.

We are adding: 

* a next.js [API route ](https://nextjs.org/docs/api-routes/introduction) to enable preview mode
* another API route to terminate the preview mode
* a button only visible in preview mode to terminate the preview mode (by calling the api route)

We are also modifying the `pages/[...slug].js` file to show unpublished content if preview is active.